### PR TITLE
프로젝트 전체적으로 오타 수정 및 코드 일관성 향상

### DIFF
--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/config/ComputerKurzweilProperties.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/config/ComputerKurzweilProperties.java
@@ -44,7 +44,7 @@ public class ComputerKurzweilProperties {
     public Cca cca = new Cca();
 
     @Valid
-    public WienerProcess randomwalk = new WienerProcess();
+    public WienerProcess randomWalk = new WienerProcess();
 
     @Valid
     public Dla dla = new Dla();

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/SimulatedEvolutionModel.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/SimulatedEvolutionModel.java
@@ -108,14 +108,9 @@ public class SimulatedEvolutionModel implements Serializable {
         );
         cells = new ArrayList<Cell>();
         for (int i = 0; i < initialPopulation; i++) {
-            int x = random.nextInt(worldDimensions.getX());
-            int y = random.nextInt(worldDimensions.getY());
-            if (x < 0) {
-                x *= -1;
-            }
-            if (y < 0) {
-                y *= -1;
-            }
+            int x = Math.abs(random.nextInt(worldDimensions.getX()));
+            int y = Math.abs(random.nextInt(worldDimensions.getY()));
+
             LatticePoint pos = new LatticePoint(x, y);
             Cell cell = new Cell(worldDimensions, pos, random);
             cells.add(cell);

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/cell/Cell.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/cell/Cell.java
@@ -91,9 +91,7 @@ public class Cell implements Serializable {
     private Orientation getRandomOrientation() {
         int dnaLength = Orientation.values().length;
         int dnaBase = random.nextInt(dnaLength);
-        if (dnaBase < 0) {
-            dnaBase *= -1;
-        }
+        dnaBase = Math.abs(dnaBase);
         return Orientation.values()[dnaBase];
     }
 

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/food/SimulatedEvolutionWorldLattice.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/food/SimulatedEvolutionWorldLattice.java
@@ -45,7 +45,7 @@ public class SimulatedEvolutionWorldLattice implements Serializable {
      * As a Result of Evolution you will find sucessful Bacteria Cells
      * with a different DNA and Motion as outside the Garden of Eden.
      */
-    private final boolean EABLE_GARDEN_OF_EDEN = true;
+    private final boolean ENABLE_GARDEN_OF_EDEN = true;
 
     /**
      * Random Generator used for placing food, coming from another Object.
@@ -69,7 +69,7 @@ public class SimulatedEvolutionWorldLattice implements Serializable {
             food++;
             int x = Math.abs(random.nextInt(limitX));
             int y = Math.abs(random.nextInt(limitY));
-        
+
             worldMapFood[startX*2+x][startY*2+y]++;
         }
     }
@@ -81,7 +81,7 @@ public class SimulatedEvolutionWorldLattice implements Serializable {
         int limitX = this.dimensions.getX();
         int limitY = this.dimensions.getY();
         generateFood(FOOD_PER_DAY, 0, 0, limitX, limitY);
-        if (EABLE_GARDEN_OF_EDEN) {
+        if (ENABLE_GARDEN_OF_EDEN) {
             generateFood(FOOD_PER_DAY*4, limitX / 5, limitY / 5, limitX / 5, limitY / 5);
         }
     }
@@ -100,12 +100,18 @@ public class SimulatedEvolutionWorldLattice implements Serializable {
      * @return the engergy of the food, will be added to cell's fat.
      */
     public int eat(LatticePoint position) {
-        LatticePoint neighbourhood[] = position.getNeighbourhood(this.dimensions);
+        LatticePoint[] neighbourhood = position.getNeighbourhood(this.dimensions);
         int food=0;
         for (LatticePoint neighbourhoodPosition:neighbourhood){
-            food += worldMapFood[neighbourhoodPosition.getX()][neighbourhoodPosition.getY()];
-            worldMapFood[neighbourhoodPosition.getX()][neighbourhoodPosition.getY()]=0;
+            food = swapValues(food, neighbourhoodPosition);
         }
         return food;
     }
+
+    private int swapValues(int food, LatticePoint neighbourhoodPosition) {
+        food += worldMapFood[neighbourhoodPosition.getX()][neighbourhoodPosition.getY()];
+        worldMapFood[neighbourhoodPosition.getX()][neighbourhoodPosition.getY()]=0;
+        return food;
+    }
+
 }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeDimension.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeDimension.java
@@ -34,7 +34,6 @@ public class LatticeDimension implements Serializable {
     public void plusAndAbsolute(LatticeDimension p) {
         width = Math.abs(width + p.getWidth());
         height = Math.abs(height + p.getHeight());
-        makePositive();
     }
 
     public LatticeDimension copy() {

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeDimension.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeDimension.java
@@ -26,15 +26,15 @@ public class LatticeDimension implements Serializable {
      */
     private int height;
 
-    public void absoluteValue() {
-        width *= Integer.signum(width);
-        height *= Integer.signum(height);
+    public void makePositive() {
+        width = Math.abs(width);
+        height = Math.abs(height);
     }
 
-    public void plus(LatticeDimension p) {
-        this.width += p.getWidth();
-        this.height += p.getHeight();
-        absoluteValue();
+    public void plusAndAbsolute(LatticeDimension p) {
+        width = Math.abs(width + p.getWidth());
+        height = Math.abs(height + p.getHeight());
+        makePositive();
     }
 
     public LatticeDimension copy() {
@@ -50,7 +50,7 @@ public class LatticeDimension implements Serializable {
             this.getHeight()
         );
     }
-    
+
     public static LatticeDimension of(LatticePoint p) {
         return new LatticeDimension(p.getX(), p.getY());
     }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticePoint.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticePoint.java
@@ -31,6 +31,13 @@ import java.io.Serializable;
 @EqualsAndHashCode
 public class LatticePoint implements Serializable {
 
+    private static int[][] OFFSETS = {
+        {-1, -1}, {-1, 0}, {-1, 1},
+        {0, -1},  {0, 0},  {0, 1},
+        {1, -1},  {1, 0},  {1, 1}
+    };
+    private static int OFFSET_MIN = 0;
+    private static int OFFSET_MAX = 1;
     static final long serialVersionUID = 242L;
 
 
@@ -84,20 +91,15 @@ public class LatticePoint implements Serializable {
      * @param max - limit the dimensions of the world around
      * @return The Set of Points belonging to the Neighbourhood of the position given by this Point Object.
      */
-    public LatticePoint[] getNeighbourhood(LatticePoint max) {
-        int[][] offsets = {
-            {-1, -1}, {-1, 0}, {-1, 1},
-            {0, -1},  {0, 0},  {0, 1},
-            {1, -1},  {1, 0},  {1, 1}
-        };
 
+    public LatticePoint[] getNeighbourhood(LatticePoint max) {
         LatticePoint[] neighbourhood = new LatticePoint[9];
         int maxX = max.getX();
         int maxY = max.getY();
 
         for (int i = 0; i < neighbourhood.length; i++) {
-            int offsetX = offsets[i][0];
-            int offsetY = offsets[i][1];
+            int offsetX = OFFSETS[i][OFFSET_MIN];
+            int offsetY = OFFSETS[i][OFFSET_MAX];
             int newX = (this.x + maxX + offsetX) % maxX;
             int newY = (this.y + maxY + offsetY) % maxY;
             neighbourhood[i] = new LatticePoint(newX, newY);

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeRectangle.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/geometry/LatticeRectangle.java
@@ -20,14 +20,12 @@ public class LatticeRectangle implements Serializable {
     private LatticeDimension dimension;
 
     public static LatticeRectangle of(LatticePoint start, LatticeDimension dimension){
-        LatticeRectangle lb = new LatticeRectangle(start, dimension);
-        return lb;
+        return new LatticeRectangle(start, dimension);
     }
 
     public static LatticeRectangle of(int startX, int  startY, int width, int height){
         LatticePoint start = new LatticePoint(startX, startY);
         LatticeDimension dimension = new LatticeDimension(width, height);
-        LatticeRectangle lb = new LatticeRectangle(start, dimension);
-        return lb;
+        return new LatticeRectangle(start, dimension);
     }
 }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhood.java
@@ -8,6 +8,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.geometry.LatticeP
 
 import java.io.Serializable;
 
+import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.getNeighbourhoodFor;
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodType.*;
 
 /**
@@ -53,7 +54,7 @@ public class LatticePointNeighbourhood implements Serializable {
      */
     private LatticePoint[] getNeighbourhoodPoints() {
 
-        LatticePointNeighbourhoodPosition[] positions = LatticePointNeighbourhoodPosition.getNeighbourhoodFor(neighbourhoodType);
+        LatticePointNeighbourhoodPosition[] positions = getNeighbourhoodFor(neighbourhoodType);
         this.neighbourhood = new LatticePoint[positions.length];
         for(int i = 0; i < positions.length; i++){
             this.neighbourhood[i] = new LatticePoint(
@@ -76,7 +77,7 @@ public class LatticePointNeighbourhood implements Serializable {
         return getNeighbour(worldX, worldY, mX, mY,VON_NEUMANN_NEIGHBORHOOD);
     }
 
-    public LatticePoint[] getWoehlke(int worldX, int worldY, int mX, int mY) {
+    public LatticePoint[] getUserDefineType(int worldX, int worldY, int mX, int mY) {
         return getNeighbour(worldX, worldY, mX,mY, USER_DEFINE_NEIGHBORHOOD);
     }
 

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhood.java
@@ -52,6 +52,7 @@ public class LatticePointNeighbourhood implements Serializable {
      * @return The Set of Points belonging to the Neighbourhood of the position given by this Point Object.
      */
     private LatticePoint[] getNeighbourhoodPoints() {
+
         LatticePointNeighbourhoodPosition[] positions = LatticePointNeighbourhoodPosition.getNeighbourhoodFor(neighbourhoodType);
         this.neighbourhood = new LatticePoint[positions.length];
         for(int i = 0; i < positions.length; i++){
@@ -76,7 +77,7 @@ public class LatticePointNeighbourhood implements Serializable {
     }
 
     public LatticePoint[] getWoehlke(int worldX, int worldY, int mX, int mY) {
-        return getNeighbour(worldX, worldY, mX,mY, WOEHLKE_NEIGHBORHOOD);
+        return getNeighbour(worldX, worldY, mX,mY, USER_DEFINE_NEIGHBORHOOD);
     }
 
     private static LatticePoint[] getNeighbour(int worldX, int worldY, int mX, int mY, LatticePointNeighbourhoodType type){
@@ -84,3 +85,4 @@ public class LatticePointNeighbourhood implements Serializable {
     }
 
 }
+

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhoodPosition.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhoodPosition.java
@@ -1,11 +1,10 @@
 package org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood;
 
 import lombok.Getter;
-import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.neighbourhoodposition.Neighbourhoods;
 
 import java.io.Serializable;
 
-import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.neighbourhoodposition.Neighbourhoods.NeighbourhoodFactory;
+import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.neighbourhoodposition.NeighbourhoodFactory.NeighbourhoodFactory;
 
 /**
  * &copy; 2006 - 2008 Thomas Woehlke.

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhoodType.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/LatticePointNeighbourhoodType.java
@@ -33,5 +33,5 @@ public enum LatticePointNeighbourhoodType {
      * |#|*|#|
      * |#|#|#|
      */
-    WOEHLKE_NEIGHBORHOOD;
+    USER_DEFINE_NEIGHBORHOOD;
 }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/MooreNeighborhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/MooreNeighborhood.java
@@ -4,7 +4,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.Lat
 
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.*;
 
-public class MooreNeighborhood extends Neighbourhoods {
+public class MooreNeighborhood extends NeighbourhoodFactory {
     @Override
     public LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions() {
         LatticePointNeighbourhoodPosition[] result = new LatticePointNeighbourhoodPosition[8];

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/NeighbourhoodFactory.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/NeighbourhoodFactory.java
@@ -12,7 +12,7 @@ public abstract class NeighbourhoodFactory {
             case VON_NEUMANN_NEIGHBORHOOD -> result = new VonNeumannNeighborhood().getNeighbourhoodPositions();
             case MOORE_NEIGHBORHOOD ->  result = new MooreNeighborhood().getNeighbourhoodPositions();
             case USER_DEFINE_NEIGHBORHOOD -> result = new WoehlkeNeighbourhood().getNeighbourhoodPositions();
-            default -> result =  new Others().getNeighbourhoodPositions();
+            default -> result =  new OtherNeighbourhood().getNeighbourhoodPositions();
         }
         return result;
     }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/NeighbourhoodFactory.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/NeighbourhoodFactory.java
@@ -3,7 +3,7 @@ package org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.ne
 import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition;
 import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodType;
 
-public abstract class Neighbourhoods {
+public abstract class NeighbourhoodFactory {
     public abstract LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions();
 
     public static LatticePointNeighbourhoodPosition[] NeighbourhoodFactory(LatticePointNeighbourhoodType type){
@@ -11,7 +11,7 @@ public abstract class Neighbourhoods {
         switch (type){
             case VON_NEUMANN_NEIGHBORHOOD -> result = new VonNeumannNeighborhood().getNeighbourhoodPositions();
             case MOORE_NEIGHBORHOOD ->  result = new MooreNeighborhood().getNeighbourhoodPositions();
-            case WOEHLKE_NEIGHBORHOOD -> result = new WoehlkeNeighbourhood().getNeighbourhoodPositions();
+            case USER_DEFINE_NEIGHBORHOOD -> result = new WoehlkeNeighbourhood().getNeighbourhoodPositions();
             default -> result =  new Others().getNeighbourhoodPositions();
         }
         return result;

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/OtherNeighbourhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/OtherNeighbourhood.java
@@ -4,7 +4,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.Lat
 
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.CENTER;
 
-public class Others extends NeighbourhoodFactory {
+public class OtherNeighbourhood extends NeighbourhoodFactory {
     @Override
     public LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions() {
         LatticePointNeighbourhoodPosition[] result = new LatticePointNeighbourhoodPosition[1];

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/Others.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/Others.java
@@ -4,7 +4,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.Lat
 
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.CENTER;
 
-public class Others extends Neighbourhoods {
+public class Others extends NeighbourhoodFactory {
     @Override
     public LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions() {
         LatticePointNeighbourhoodPosition[] result = new LatticePointNeighbourhoodPosition[1];

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/VonNeumannNeighborhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/VonNeumannNeighborhood.java
@@ -4,7 +4,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.Lat
 
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.*;
 
-public class VonNeumannNeighborhood extends Neighbourhoods {
+public class VonNeumannNeighborhood extends NeighbourhoodFactory {
     @Override
     public LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions() {
         LatticePointNeighbourhoodPosition[] result = new LatticePointNeighbourhoodPosition[4];

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/WoehlkeNeighbourhood.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/neighbourhood/neighbourhoodposition/WoehlkeNeighbourhood.java
@@ -4,7 +4,7 @@ import org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.Lat
 
 import static org.woehlke.computer.kurzweil.simulated.evolution.model.neighbourhood.LatticePointNeighbourhoodPosition.*;
 
-public class WoehlkeNeighbourhood extends Neighbourhoods {
+public class WoehlkeNeighbourhood extends NeighbourhoodFactory {
     @Override
     public LatticePointNeighbourhoodPosition[] getNeighbourhoodPositions() {
         LatticePointNeighbourhoodPosition[] result = new LatticePointNeighbourhoodPosition[6];

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/view/canvas/CensusCanvas.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/view/canvas/CensusCanvas.java
@@ -39,13 +39,13 @@ public class CensusCanvas extends JComponent implements Serializable {
 
     private final Color paper;
 
-    private final LatticeDimension canvasdDimensions;
+    private final LatticeDimension canvasDimensions;
 
     public CensusCanvas(SimulatedEvolutionModel tabModel) {
         int width = tabModel.getWorldDimensions().getX();
         int height = tabModel.getProperties().getSimulatedevolution().getView().getHeightOfStatisticsCanvas();
         this.container = tabModel.getCensusContainer();
-        this.canvasdDimensions = LatticeDimension.of(width,height);
+        this.canvasDimensions = LatticeDimension.of(width,height);
         Dimension preferredSize = new Dimension(width, height);
         this.setSize(preferredSize);
         this.setPreferredSize(preferredSize);
@@ -55,8 +55,8 @@ public class CensusCanvas extends JComponent implements Serializable {
     }
 
     public void showMe(){
-        int width = canvasdDimensions.getWidth();
-        int height = canvasdDimensions.getHeight();
+        int width = canvasDimensions.getWidth();
+        int height = canvasDimensions.getHeight();
         Dimension preferredSize = new Dimension(width, height);
         this.setSize(preferredSize);
         this.setBackground(this.paper);
@@ -71,8 +71,8 @@ public class CensusCanvas extends JComponent implements Serializable {
         super.paintComponent(g);
         int x = 0;
         int y = 0;
-        int width = this.canvasdDimensions.getWidth();
-        int height = this.canvasdDimensions.getHeight();
+        int width = this.canvasDimensions.getWidth();
+        int height = this.canvasDimensions.getHeight();
         g.setColor(Color.LIGHT_GRAY);
         g.fillRect(x,y,width,height);
         g.setColor(Color.RED);


### PR DESCRIPTION
1. 코드 오타 수정
2. 절대값 취하는 코드들을 전체적으로 수정함.
3. 조교님이 언급하신 애매한 enum type 명 변경