### PR TITLE
Censusstatus package : Junit Test for CensusStatus class

### DIFF
--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/SimulatedEvolutionPopulationCensus.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/SimulatedEvolutionPopulationCensus.java
@@ -27,7 +27,7 @@ public class SimulatedEvolutionPopulationCensus implements Serializable {
 
     private int youngCells;
     private int youngAndFatCells;
-    private int fullAgeCells;
+    private int adultCells;
     private int hungryCells;
     private int oldCells;
     private int deadCells;
@@ -66,7 +66,7 @@ public class SimulatedEvolutionPopulationCensus implements Serializable {
     }
 
     public void incrementFullAgeCells(){
-        fullAgeCells++;
+        adultCells++;
     }
     public void incrementHungryCells(){
         hungryCells++;

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/AdultAgeStatus.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/AdultAgeStatus.java
@@ -1,6 +1,5 @@
 package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
 
-import jakarta.validation.Valid;
 import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
 
 import java.awt.*;
@@ -31,7 +30,7 @@ public class AdultAgeStatus implements CensusCellStatus{
 
     @Override
     public int getCellsNumber(SimulatedEvolutionPopulationCensus census){
-        return census.getFullAgeCells();
+        return census.getAdultCells();
     }
 
 }

--- a/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/view/census/CensusElementsPanelLifeCycle.java
+++ b/src/main/java/org/woehlke/computer/kurzweil/simulated/evolution/view/census/CensusElementsPanelLifeCycle.java
@@ -76,7 +76,7 @@ public class CensusElementsPanelLifeCycle extends JPanel implements Serializable
         SimulatedEvolutionPopulationCensus population = this.container.peek();
         youngCellsElement.setText(population.getYoungCells());
         youngAndFatCellsElement.setText(population.getYoungAndFatCells());
-        adultAgeCellsElement.setText(population.getFullAgeCells());
+        adultAgeCellsElement.setText(population.getAdultCells());
         hungryCellsElement.setText(population.getHungryCells());
         oldCellsElement.setText(population.getOldCells());
         wholeGeneration.setText(population.getPopulation());

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/AdultAgeStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/AdultAgeStatusTest.java
@@ -1,0 +1,40 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+import org.junit.*;
+
+public class AdultAgeStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new AdultAgeStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.RED);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.WHITE);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.RED);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/DeadStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/DeadStatusTest.java
@@ -1,0 +1,38 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class DeadStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new DeadStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.BLACK);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.WHITE);
+    }
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.BLACK);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/HungryStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/HungryStatusTest.java
@@ -1,0 +1,39 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class HungryStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new HungryStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.LIGHT_GRAY);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.BLACK);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.LIGHT_GRAY);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/OldStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/OldStatusTest.java
@@ -1,0 +1,39 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class OldStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new OldStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.DARK_GRAY);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.WHITE);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.DARK_GRAY);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/PopulationStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/PopulationStatusTest.java
@@ -1,0 +1,39 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class PopulationStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new PopulationStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.WHITE);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.BLACK);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.WHITE);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/YoungAndFatStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/YoungAndFatStatusTest.java
@@ -1,0 +1,39 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class YoungAndFatStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new YoungAndFatStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.YELLOW);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.BLACK);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.YELLOW);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/YoungStatusTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/model/census/censusstatus/YoungStatusTest.java
@@ -1,0 +1,39 @@
+package org.woehlke.computer.kurzweil.simulated.evolution.model.census.censusstatus;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.woehlke.computer.kurzweil.simulated.evolution.model.census.SimulatedEvolutionPopulationCensus;
+
+import java.awt.*;
+
+public class YoungStatusTest {
+    private static CensusCellStatus status;
+    private static SimulatedEvolutionPopulationCensus census;
+    @BeforeClass
+    public static void setup(){
+        status = new YoungStatus();
+        census = new SimulatedEvolutionPopulationCensus(0);
+    }
+
+    @Test
+    public void countStatus() {
+        int beforeAdultCells = status.getCellsNumber(census);
+        status.countStatus(census);
+        Assert.assertEquals(beforeAdultCells + 1,  status.getCellsNumber(census));
+    }
+    @Test
+    public void getColor() {
+        Assert.assertSame(status.getColor(),Color.BLUE);
+    }
+
+    @Test
+    public void getColorForeground() {
+        Assert.assertSame(status.getColorForeground(),Color.WHITE);
+    }
+
+    @Test
+    public void getColorBackground() {
+        Assert.assertSame(status.getColorBackground(),Color.BLUE);
+    }
+}

--- a/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/view/canvas/CensusCanvasTest.java
+++ b/src/test/java/org/woehlke/computer/kurzweil/simulated/evolution/view/canvas/CensusCanvasTest.java
@@ -29,7 +29,7 @@ public class CensusCanvasTest {
         census = new SimulatedEvolutionPopulationCensus(0);
         census.setYoungCells(YOUNGCELL);
         census.setYoungAndFatCells(YOUNGANDFATCELLS);
-        census.setFullAgeCells(ADULTCELLS);
+        census.setAdultCells(ADULTCELLS);
         census.setHungryCells(HUNGRYCELLS);
         census.setOldCells(OLDCELLS);
         census.setDeadCells(DEADCELLS);


### PR DESCRIPTION
Testing 7 CensusStatus classes which implement CensusCellStatus. Testing countStutus, getColor, getColorForeground, getColorBackground, getCellNumber().
Also fix remained name "fullAgeCells" to "adultCells" in SimulatedEvolutionPopulationCensus.java file.